### PR TITLE
fix py3MangosToCN_linux.py crash

### DIFF
--- a/py3MangosToCN_linux.py
+++ b/py3MangosToCN_linux.py
@@ -85,7 +85,7 @@ path2 = path + "Translations/" + langFolderName + "/"
 langFiles = os.listdir(path2)
 
 for filename in langFiles:
-    if os.path.isdir(path2 + filename) is True or filename.rsplit(".", 1)[1].lower() != "sql":
+    if os.path.isdir(path2 + filename) or not filename.endswith(".sql"):
         continue
     
     print(sqlExecCMD  + path2 + filename)


### PR DESCRIPTION
fix crash caused by file name '--== DO NOT COMMIT FILES TO THIS FOLDER ==--' and '--== MAKE THEM IN TRANSLATIONS_TODO  ==--'